### PR TITLE
fix: resolve the bug of new package version not exist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15666,9 +15666,20 @@ async function run() {
 
     const currentVersionURL = `https://raw.githubusercontent.com/${github.context.repo.owner}/${github.context.repo.repo}/${baseSHA}${workingDirectory}version`;
     core.info(`current version url: ${currentVersionURL}`);
-    let { data: currentVersion } = await axios.get(currentVersionURL, {
-      headers,
-    });
+    let { data: currentVersion } = await axios
+      .get(currentVersionURL, {
+        headers,
+      })
+      .catch((error) => {
+        // if status code 404, old version file is not exist, setup version to 0.0.0
+        if (error.response && error.response.status === 404) {
+          return {
+            data: '0.0.0',
+          };
+        }
+        throw error;
+      });
+
     currentVersion = currentVersion.toString().trim();
 
     const nextVersionURL = `https://raw.githubusercontent.com/${github.context.repo.owner}/${github.context.repo.repo}/${headSHA}${workingDirectory}version`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-version-check",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Check if the current version is compliant with the specification",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -69,9 +69,20 @@ async function run() {
 
     const currentVersionURL = `https://raw.githubusercontent.com/${github.context.repo.owner}/${github.context.repo.repo}/${baseSHA}${workingDirectory}version`;
     core.info(`current version url: ${currentVersionURL}`);
-    let { data: currentVersion } = await axios.get(currentVersionURL, {
-      headers,
-    });
+    let { data: currentVersion } = await axios
+      .get(currentVersionURL, {
+        headers,
+      })
+      .catch((error) => {
+        // if status code 404, old version file is not exist, setup version to 0.0.0
+        if (error.response && error.response.status === 404) {
+          return {
+            data: '0.0.0',
+          };
+        }
+        throw error;
+      });
+
     currentVersion = currentVersion.toString().trim();
 
     const nextVersionURL = `https://raw.githubusercontent.com/${github.context.repo.owner}/${github.context.repo.repo}/${headSHA}${workingDirectory}version`;


### PR DESCRIPTION
### 修改内容
1. 如果分支的 version 文件请求为 404，默认把 currentVersion 设为 0.0.0，防止新的包或者新的 blcoklet，version check 不过关